### PR TITLE
python-challenge solution

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -70,7 +70,7 @@ def main(event, context=None):  # pylint: disable=unused-argument
             )
             continue
 
-    logger.info('Service recieved loans: %s', json.dumps(loans, indent=2))
+    logger.info('Service received loans: %s', json.dumps(loans, indent=2))
 
     # Generate Manifests
     reports = []

--- a/handler.py
+++ b/handler.py
@@ -87,15 +87,6 @@ def main(event, context=None):  # pylint: disable=unused-argument
 
     for i in range(applications_size):
         if f"$.applications[{i}].borrower" not in application_rules:
-            #Add multiple residences in report
-            rules.append({'source': f"$.applications[{i}].borrower.mailingAddress.addressStreetLine1",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i}].street"})
-            rules.append({'source': f"$.applications[{i}].borrower.mailingAddress.addressState",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i}].state"})
-            rules.append({'source': f"$.applications[{i}].borrower.mailingAddress.addressCity",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i}].city"})
-            rules.append({'source': f"$.applications[{i}].borrower.mailingAddress.addressPostalCode",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i}].zip"})
-            rules.append({'source': f"$.applications[{i}].coborrower.mailingAddress.addressStreetLine1",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i+1}].street"})
-            rules.append({'source': f"$.applications[{i}].coborrower.mailingAddress.addressState",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i+1}].state"})
-            rules.append({'source': f"$.applications[{i}].coborrower.mailingAddress.addressCity",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i+1}].city"})
-            rules.append({'source': f"$.applications[{i}].coborrower.mailingAddress.addressPostalCode",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i+1}].zip"})
             #Add multiple borrowers in report
             rules.append({'source':f"$.applications[{i}].borrower.firstName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i}].first_name" })
             rules.append({'source':f"$.applications[{i}].borrower.lastName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i}].last_name" })

--- a/handler.py
+++ b/handler.py
@@ -79,7 +79,7 @@ def main(event, context=None):  # pylint: disable=unused-argument
     logger.info('Service received loans: %s', json.dumps(loans, indent=2))
     #added bug fix for CC-03
 
-    """
+
     applications = loans[0]['applications']
     applications_size = len(applications)
     #load application rules
@@ -101,11 +101,8 @@ def main(event, context=None):  # pylint: disable=unused-argument
             rules.append({'source':f"$.applications[{i}].borrower.lastName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i}].last_name" })
             rules.append({'source':f"$.applications[{i}].coborrower.firstName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i+1}].first_name" })
             rules.append({'source':f"$.applications[{i}].coborrower.lastName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i+1}].last_name" })
-            rules.append({
-                "source": "$.reports[?(@.title == 'Borrowers Report')].shared_address",
-                "target": "$.reports[?(@.title == 'Borrowers Report')].shared_address"
-            })
-    """
+            
+
     # Generate Manifests
     reports = []
     for loan in loans:

--- a/handler.py
+++ b/handler.py
@@ -51,7 +51,7 @@ def main(event, context=None):  # pylint: disable=unused-argument
     rules = [rule for _ in project.resources.values() for rule in _]
     #Added new rule for [FTR] CC-02
     rules.append({
-        "source": "$.reports[?(@.title == 'Borrowers Report')].shared_address",
+        "source": "$.applications[0].shared_address",
         "target": "$.reports[?(@.title == 'Borrowers Report')].shared_address"
     })
 
@@ -77,7 +77,7 @@ def main(event, context=None):  # pylint: disable=unused-argument
             continue
 
     logger.info('Service received loans: %s', json.dumps(loans, indent=2))
-    """
+
     #added bug fix for CC-03
     applications = loans[0]['applications']
     applications_size = len(applications)
@@ -86,14 +86,25 @@ def main(event, context=None):  # pylint: disable=unused-argument
     #add new rules based on size of applications
 
     for i in range(applications_size):
-        if f"$.applications[{i}].borrower" not in application_rules:
+        if f"$.applications[{i}].borrower" not in application_rules and f"$.applications[{i}].coborrower" not in application_rules:
+            #Add multiple residences in report
+            rules.append({'source': f"$.applications[{i}].borrower.mailingAddress.addressStreetLine1",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i}].street"})
+            rules.append({'source': f"$.applications[{i}].borrower.mailingAddress.addressState",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i}].state"})
+            rules.append({'source': f"$.applications[{i}].borrower.mailingAddress.addressCity",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i}].city"})
+            rules.append({'source': f"$.applications[{i}].borrower.mailingAddress.addressPostalCode",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i}].zip"})
+            rules.append({'source': f"$.applications[{i}].coborrower.mailingAddress.addressStreetLine1",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i+1}].street"})
+            rules.append({'source': f"$.applications[{i}].coborrower.mailingAddress.addressState",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i+1}].state"})
+            rules.append({'source': f"$.applications[{i}].coborrower.mailingAddress.addressCity",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i+1}].city"})
+            rules.append({'source': f"$.applications[{i}].coborrower.mailingAddress.addressPostalCode",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i+1}].zip"})
+            #even index of borrowers list in report are borrowers
+            #odd index of borrowers list in report are coborrowers
             #Add multiple borrowers in report
             rules.append({'source':f"$.applications[{i}].borrower.firstName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i}].first_name" })
             rules.append({'source':f"$.applications[{i}].borrower.lastName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i}].last_name" })
             rules.append({'source':f"$.applications[{i}].coborrower.firstName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i+1}].first_name" })
             rules.append({'source':f"$.applications[{i}].coborrower.lastName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i+1}].last_name" })
 
-    """
+
 
     # Generate Manifests
     reports = []

--- a/handler.py
+++ b/handler.py
@@ -50,6 +50,12 @@ def main(event, context=None):  # pylint: disable=unused-argument
     rules = [rule for _ in project.resources.values() for rule in _]
     logger.info('Service loaded rules: %s', json.dumps(rules, indent=2))
 
+    #Added new rule for [FTR] CC-02
+    rules.append({
+        "source": "$.reports[?(@.title == 'Borrowers Report')].shared_address",
+        "target": "$.reports[?(@.title == 'Borrowers Report')].shared_address"
+    })
+
     # Confirm event is valid EventBridge -> SQS payload
     loans = []
     for record in event.get('Records', [{}]):

--- a/handler.py
+++ b/handler.py
@@ -77,16 +77,16 @@ def main(event, context=None):  # pylint: disable=unused-argument
             continue
 
     logger.info('Service received loans: %s', json.dumps(loans, indent=2))
+    """
     #added bug fix for CC-03
-
-
     applications = loans[0]['applications']
     applications_size = len(applications)
     #load application rules
     application_rules = [rule['source'] for rule in rules]
     #add new rules based on size of applications
+
     for i in range(applications_size):
-        if f"$.applications[{i}]" not in application_rules:
+        if f"$.applications[{i}].borrower" not in application_rules:
             #Add multiple residences in report
             rules.append({'source': f"$.applications[{i}].borrower.mailingAddress.addressStreetLine1",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i}].street"})
             rules.append({'source': f"$.applications[{i}].borrower.mailingAddress.addressState",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i}].state"})
@@ -101,7 +101,8 @@ def main(event, context=None):  # pylint: disable=unused-argument
             rules.append({'source':f"$.applications[{i}].borrower.lastName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i}].last_name" })
             rules.append({'source':f"$.applications[{i}].coborrower.firstName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i+1}].first_name" })
             rules.append({'source':f"$.applications[{i}].coborrower.lastName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i+1}].last_name" })
-            
+
+    """
 
     # Generate Manifests
     reports = []

--- a/service/models.py
+++ b/service/models.py
@@ -354,23 +354,21 @@ class JSONFactory:
 
     #Added Code
 
-    def _address_validator(self):
+    def _address_validator(self,index):
         """
         This method compares the borrower's and co-borrower's residence addresses.
         It checks if the residence addresses are the same.
         The residence addresses are the same if the street, city, state, and zip are the same.
         """
-        data_length = len(self._manifest.data['applications'])
+        is_same_street = self._manifest._fdata.get(f"$.applications[{index}].borrower.mailingAddress.addressStreetLine1") \
+        == self._manifest._fdata.get(f"$.applications[{index}].coborrower.mailingAddress.addressStreetLine1")
+        is_same_state = self._manifest._fdata.get(f"$.applications[{index}].borrower.mailingAddress.addressState") \
+        == self._manifest._fdata.get(f"$.applications[{index}].coborrower.mailingAddress.addressState")
+        is_same_city = self._manifest._fdata.get(f"$.applications[{index}].borrower.mailingAddress.addressCity") \
+        == self._manifest._fdata.get(f"$.applications[{index}].coborrower.mailingAddress.addressCity")
+        is_same_zip = self._manifest._fdata.get(f"$.applications[{index}].borrower.mailingAddress.addressPostalCode") \
+        == self._manifest._fdata.get(f"$.applications[{index}].coborrower.mailingAddress.addressPostalCode")
 
-        for i in range(data_length):
-            is_same_street = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressStreetLine1") \
-            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressStreetLine1")
-            is_same_state = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressState") \
-            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressState")
-            is_same_city = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressCity") \
-            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressCity")
-            is_same_zip = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressPostalCode") \
-            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressPostalCode")
         return is_same_street and is_same_state and is_same_city and is_same_zip
 
 
@@ -384,7 +382,7 @@ class JSONFactory:
         """
         data_length = len(self._manifest.data['applications'])
         for i in range(data_length):
-            if self._address_validator():
+            if self._address_validator(i):
                 self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressStreetLine1")
                 self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressState")
                 self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressPostalCode")
@@ -399,10 +397,12 @@ class JSONFactory:
         to determine if the borrower and coborrower live together.
         The borrower and coborrower live together if they both share the same address
         """
-        if self._address_validator():
-            self._manifest._fdata.__setitem__(f"$.reports[?(@.title == 'Borrowers Report')].shared_address", True)
-        else:
-            self._manifest._fdata.__setitem__(f"$.reports[?(@.title == 'Borrowers Report')].shared_address", False)
+        data_length = len(self._manifest.data['applications'])
+        for i in range(data_length):
+            if self._address_validator(i):
+                self._manifest._fdata.__setitem__(f"$.applications[{i}].shared_address", True)
+            else:
+                self._manifest._fdata.__setitem__(f"$.applications[{i}].shared_address", False)
 
 
 

--- a/service/models.py
+++ b/service/models.py
@@ -350,6 +350,49 @@ class JSONFactory:
     def __init__(self, manifest: JSONManifest):
         self._manifest = manifest
 
+
+    #Added Code
+
+    def _address_validator(self):
+        """
+        This method compares the borrower and co-borrowers residence addresses.
+        It checks if the residence addresses are the same.
+        The residence addresses are the same if the street, city, state, and zip are the same.
+        """
+        borrower = 0
+        coborrower = 1
+        is_same_street = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].street"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].street"]
+
+        is_same_city = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].city"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].city"]
+
+        is_same_state = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].state"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].state"]
+
+        is_same_zip = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].zip"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].zip"]
+
+        return is_same_street and is_same_city and is_same_state and is_same_zip
+
+
+
+
+
+    def _remove_duplicate_residences(self):
+        """
+        Remove duplicate residences
+        if the borrower's residence is the same as the coborrowers residence
+        Part of ticket [FTR] CC-01
+        """
+        if self._address_validator():
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressStreetLine1")
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressState")
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressPostalCode")
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressCity")
+
+
+
     # Instance methods
     def get_projection(self):
         """Generate the projection for the given manifest.
@@ -361,6 +404,7 @@ class JSONFactory:
 
         """
         queries, record = [], {}
+        self._remove_duplicate_residences()
         for path, value in self._manifest:
 
             # Prioritize non-queries before queries

--- a/service/models.py
+++ b/service/models.py
@@ -350,6 +350,57 @@ class JSONFactory:
     def __init__(self, manifest: JSONManifest):
         self._manifest = manifest
 
+       #Added Code
+
+    def _address_validator(self):
+        """
+        This method compares the borrower and co-borrowers residence addresses.
+        It checks if the residence addresses are the same.
+        The residence addresses are the same if the street, city, state, and zip are the same.
+        """
+        borrower = 0
+        coborrower = 1
+        is_same_street = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].street"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].street"]
+
+        is_same_city = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].city"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].city"]
+
+        is_same_state = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].state"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].state"]
+
+        is_same_zip = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].zip"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].zip"]
+
+        return is_same_street and is_same_city and is_same_state and is_same_zip
+
+
+    def _remove_duplicate_residences(self):
+        """
+        Remove duplicate residences before generating residence reports
+        if the borrower's residence is the same as the coborrowers residence
+        Part of ticket [FTR] CC-01
+        """
+        if self._address_validator():
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressStreetLine1")
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressState")
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressPostalCode")
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressCity")
+
+    def _create_shared_address_flag(self):
+        """
+        This method creates a new flag called "shared_address" to determine if the borrower and coborrower share
+        the same address. This method depends on the address_validator method from ticket [FTR] CC-01
+        to determine if the borrower and coborrower live together.
+        The borrower and coborrower live together if they both share the same address
+        """
+        if self._address_validator():
+            self._manifest._fdata.__setitem__(f"$.reports[?(@.title == 'Borrowers Report')].shared_address", True)
+        else:
+            self._manifest._fdata.__setitem__(f"$.reports[?(@.title == 'Borrowers Report')].shared_address", False)
+
+
+
     # Instance methods
     def get_projection(self):
         """Generate the projection for the given manifest.
@@ -361,6 +412,9 @@ class JSONFactory:
 
         """
         queries, record = [], {}
+        #call these methods before generatring report
+        self._create_shared_address_flag()
+        self._remove_duplicate_residences()
         for path, value in self._manifest:
 
             # Prioritize non-queries before queries

--- a/service/models.py
+++ b/service/models.py
@@ -354,30 +354,24 @@ class JSONFactory:
 
     #Added Code
 
-
     def _address_validator(self):
         """
-        This method compares the borrower and co-borrowers residence addresses.
+        This method compares the borrower's and co-borrower's residence addresses.
         It checks if the residence addresses are the same.
         The residence addresses are the same if the street, city, state, and zip are the same.
         """
-        borrower = 0
-        coborrower = 1
-        is_same_street = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].street"] \
-        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].street"]
+        data_length = len(self._manifest.data['applications'])
 
-        is_same_city = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].city"] \
-        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].city"]
-
-        is_same_state = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].state"] \
-        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].state"]
-
-        is_same_zip = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].zip"] \
-        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].zip"]
-
-        return is_same_street and is_same_city and is_same_state and is_same_zip
-
-
+        for i in range(data_length):
+            is_same_street = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressStreetLine1") \
+            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressStreetLine1")
+            is_same_state = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressState") \
+            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressState")
+            is_same_city = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressCity") \
+            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressCity")
+            is_same_zip = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressPostalCode") \
+            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressPostalCode")
+        return is_same_street and is_same_state and is_same_city and is_same_zip
 
 
 
@@ -388,11 +382,13 @@ class JSONFactory:
         if the borrower's residence is the same as the coborrowers residence
         Part of ticket [FTR] CC-01
         """
-        if self._address_validator():
-            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressStreetLine1")
-            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressState")
-            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressPostalCode")
-            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressCity")
+        data_length = len(self._manifest.data['applications'])
+        for i in range(data_length):
+            if self._address_validator():
+                self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressStreetLine1")
+                self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressState")
+                self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressPostalCode")
+                self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressCity")
 
 
 
@@ -411,6 +407,7 @@ class JSONFactory:
 
 
 
+
     # Instance methods
     def get_projection(self):
         """Generate the projection for the given manifest.
@@ -422,14 +419,10 @@ class JSONFactory:
 
         """
         queries, record = [], {}
-
-
-        #call these methods before generatring report
+        #call these methods before generating projection
         self._create_shared_address_flag()
-
         self._remove_duplicate_residences()
         for path, value in self._manifest:
-
             # Prioritize non-queries before queries
             if '?' in path:
                 queries.append((path, value))
@@ -439,5 +432,6 @@ class JSONFactory:
 
         for path, value in queries:
             self.insert_query(path, value, record)
+
 
         return record

--- a/tests/reports.json
+++ b/tests/reports.json
@@ -8,12 +8,6 @@
           "city": "FLOWER MOUND",
           "state": "TX",
           "zip": "75028"
-        },
-        {
-          "street": "123 EXAMPLE PKWY.",
-          "city": "FLOWER MOUND",
-          "state": "TX",
-          "zip": "75028"
         }
       ]
     },

--- a/tests/reports.json
+++ b/tests/reports.json
@@ -8,12 +8,6 @@
           "city": "FLOWER MOUND",
           "state": "TX",
           "zip": "75028"
-        },
-        {
-          "street": "123 EXAMPLE PKWY.",
-          "city": "FLOWER MOUND",
-          "state": "TX",
-          "zip": "75028"
         }
       ]
     },
@@ -28,7 +22,8 @@
           "first_name": "JOHN",
           "last_name": "DOE"
         }
-      ]
+      ],
+      "shared_address": true
     }
   ]
 }

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -3,6 +3,7 @@ import sys
 import json
 import logging
 
+
 # Initialize Logging
 for handler in logging.root.handlers[:]:
     logging.root.removeHandler(handler)
@@ -46,6 +47,7 @@ if __name__ == '__main__':
 
     with open('loandata.json') as file:
         event = generate_event(json.load(file))
+
     response = main(event)
 
     logger.info('Reports: %s', json.dumps(response, indent=2))


### PR DESCRIPTION
I resolved the two tickets in the challenge. In the first ticket, I removed duplicate residences by checking for duplicate residences before displaying the report.
In the second ticket, I added a shared_address flag that denotes if the borrower and coborrower live together or not to the borrower's report. 
I also fixed the optional bug regarding the borrower's report. I have tested code for displaying multiple borrowers by adding applicants to the loandata json file. This could be discussed in more detail in the code review. I can think of at least 2 possible bugs that might be present that are not mentioned in the challenge. 
Overall, I have completed all three tickets in this challenge. The service should be able to remove duplicates and create a shared address flag as the number of applications increase.