### PR TITLE
Loans bugfix shared address

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -70,7 +70,7 @@ def main(event, context=None):  # pylint: disable=unused-argument
             )
             continue
 
-    logger.info('Service recieved loans: %s', json.dumps(loans, indent=2))
+    logger.info('Service received loans: %s', json.dumps(loans, indent=2))
 
     # Generate Manifests
     reports = []

--- a/handler.py
+++ b/handler.py
@@ -51,7 +51,7 @@ def main(event, context=None):  # pylint: disable=unused-argument
     rules = [rule for _ in project.resources.values() for rule in _]
     #Added new rule for [FTR] CC-02
     rules.append({
-        "source": "$.reports[?(@.title == 'Borrowers Report')].shared_address",
+        "source": "$.applications[0].shared_address",
         "target": "$.reports[?(@.title == 'Borrowers Report')].shared_address"
     })
 
@@ -77,16 +77,17 @@ def main(event, context=None):  # pylint: disable=unused-argument
             continue
 
     logger.info('Service received loans: %s', json.dumps(loans, indent=2))
-    #added bug fix for CC-03
 
-    """
+    
+    #added bug fix for CC-03
     applications = loans[0]['applications']
     applications_size = len(applications)
     #load application rules
     application_rules = [rule['source'] for rule in rules]
+
     #add new rules based on size of applications
     for i in range(applications_size):
-        if f"$.applications[{i}]" not in application_rules:
+        if f"$.applications[{i}].borrower" not in application_rules and f"$.applications[{i}]coborrower" not in application_rules:
             #Add multiple residences in report
             rules.append({'source': f"$.applications[{i}].borrower.mailingAddress.addressStreetLine1",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i}].street"})
             rules.append({'source': f"$.applications[{i}].borrower.mailingAddress.addressState",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i}].state"})
@@ -97,15 +98,26 @@ def main(event, context=None):  # pylint: disable=unused-argument
             rules.append({'source': f"$.applications[{i}].coborrower.mailingAddress.addressCity",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i+1}].city"})
             rules.append({'source': f"$.applications[{i}].coborrower.mailingAddress.addressPostalCode",'target':f"$.reports[?(@.title == 'Residences Report')].residences[{2*i+1}].zip"})
             #Add multiple borrowers in report
+            #even index of borrowers list in report are borrowers
+            #odd index of borrowers list in report are coborrowers
             rules.append({'source':f"$.applications[{i}].borrower.firstName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i}].first_name" })
             rules.append({'source':f"$.applications[{i}].borrower.lastName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i}].last_name" })
             rules.append({'source':f"$.applications[{i}].coborrower.firstName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i+1}].first_name" })
             rules.append({'source':f"$.applications[{i}].coborrower.lastName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i+1}].last_name" })
+            """
+            #borrowers and coborrowers both have a shared address flag
+            #Each borrower will share the same shared address flag boolean value
+            #as the borrower's respective coborrower
             rules.append({
-                "source": "$.reports[?(@.title == 'Borrowers Report')].shared_address",
-                "target": "$.reports[?(@.title == 'Borrowers Report')].shared_address"
+                "source": f"$.applications[{i}].shared_address",
+                "target": f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i}].shared_address"
             })
-    """
+            rules.append({
+                    "source": f"$.applications[{i}].shared_address",
+                    "target": f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i+1}].shared_address"
+            })
+        """
+
     # Generate Manifests
     reports = []
     for loan in loans:
@@ -122,4 +134,5 @@ def main(event, context=None):  # pylint: disable=unused-argument
         reports.extend(projection.get('reports', []))
 
     # Reformat report output and return
+
     return {'reports': reports}

--- a/handler.py
+++ b/handler.py
@@ -100,7 +100,19 @@ def main(event, context=None):  # pylint: disable=unused-argument
             rules.append({'source':f"$.applications[{i}].borrower.lastName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i}].last_name" })
             rules.append({'source':f"$.applications[{i}].coborrower.firstName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i+1}].first_name" })
             rules.append({'source':f"$.applications[{i}].coborrower.lastName", 'target': f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i+1}].last_name" })
-
+            #borrowers and coborrowers both have a shared address flag
+            #each borrower and coborrower share a shared_address flag.
+            #each borrower's shared address flag matches each respective coborrower's shared address flag
+            #in other words, each borrower will share the same shared address flag boolean value
+            # as the borrower's respective coborrower
+            rules.append({
+                "source": f"$.applications[{i}].shared_address",
+                "target": f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i}].shared_address"
+            })
+            rules.append({
+                    "source": f"$.applications[{i}].shared_address",
+                    "target": f"$.reports[?(@.title == 'Borrowers Report')].borrowers[{2*i+1}].shared_address"
+            })
     # Generate Manifests
     reports = []
     for loan in loans:

--- a/handler.py
+++ b/handler.py
@@ -50,6 +50,12 @@ def main(event, context=None):  # pylint: disable=unused-argument
     rules = [rule for _ in project.resources.values() for rule in _]
     logger.info('Service loaded rules: %s', json.dumps(rules, indent=2))
 
+    #Added new rule for [FTR] CC-02
+    rules.append({
+        "source": "$.reports[?(@.title == 'Borrowers Report')].shared_address",
+        "target": "$.reports[?(@.title == 'Borrowers Report')].shared_address"
+    })
+
     # Confirm event is valid EventBridge -> SQS payload
     loans = []
     for record in event.get('Records', [{}]):

--- a/service/models.py
+++ b/service/models.py
@@ -354,23 +354,20 @@ class JSONFactory:
 
     #Added Code
 
-    def _address_validator(self):
+    def _address_validator(self,index):
         """
         This method compares the borrower's and co-borrower's residence addresses.
         It checks if the residence addresses are the same.
         The residence addresses are the same if the street, city, state, and zip are the same.
         """
-        data_length = len(self._manifest.data['applications'])
-
-        for i in range(data_length):
-            is_same_street = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressStreetLine1") \
-            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressStreetLine1")
-            is_same_state = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressState") \
-            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressState")
-            is_same_city = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressCity") \
-            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressCity")
-            is_same_zip = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressPostalCode") \
-            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressPostalCode")
+        is_same_street = self._manifest._fdata.get(f"$.applications[{index}].borrower.mailingAddress.addressStreetLine1") \
+        == self._manifest._fdata.get(f"$.applications[{index}].coborrower.mailingAddress.addressStreetLine1")
+        is_same_state = self._manifest._fdata.get(f"$.applications[{index}].borrower.mailingAddress.addressState") \
+        == self._manifest._fdata.get(f"$.applications[{index}].coborrower.mailingAddress.addressState")
+        is_same_city = self._manifest._fdata.get(f"$.applications[{index}].borrower.mailingAddress.addressCity") \
+        == self._manifest._fdata.get(f"$.applications[{index}].coborrower.mailingAddress.addressCity")
+        is_same_zip = self._manifest._fdata.get(f"$.applications[{index}].borrower.mailingAddress.addressPostalCode") \
+        == self._manifest._fdata.get(f"$.applications[{index}].coborrower.mailingAddress.addressPostalCode")
         return is_same_street and is_same_state and is_same_city and is_same_zip
 
 
@@ -384,7 +381,7 @@ class JSONFactory:
         """
         data_length = len(self._manifest.data['applications'])
         for i in range(data_length):
-            if self._address_validator():
+            if self._address_validator(i):
                 self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressStreetLine1")
                 self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressState")
                 self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressPostalCode")
@@ -399,10 +396,12 @@ class JSONFactory:
         to determine if the borrower and coborrower live together.
         The borrower and coborrower live together if they both share the same address
         """
-        if self._address_validator():
-            self._manifest._fdata.__setitem__(f"$.reports[?(@.title == 'Borrowers Report')].shared_address", True)
-        else:
-            self._manifest._fdata.__setitem__(f"$.reports[?(@.title == 'Borrowers Report')].shared_address", False)
+        data_length = len(self._manifest.data['applications'])
+        for i in range(data_length):
+            if self._address_validator(i):
+                self._manifest._fdata.__setitem__(f"$.applications[{i}].shared_address", True)
+            else:
+                self._manifest._fdata.__setitem__(f"$.applications[{i}].shared_address", False)
 
 
 

--- a/service/models.py
+++ b/service/models.py
@@ -350,6 +350,49 @@ class JSONFactory:
     def __init__(self, manifest: JSONManifest):
         self._manifest = manifest
 
+
+    #Added Code
+
+    def _address_validator(self):
+        """
+        This method compares the borrower and co-borrowers residence addresses.
+        It checks if the residence addresses are the same.
+        The residence addresses are the same if the street, city, state, and zip are the same.
+        """
+        borrower = 0
+        coborrower = 1
+        is_same_street = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].street"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].street"]
+
+        is_same_city = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].city"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].city"]
+
+        is_same_state = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].state"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].state"]
+
+        is_same_zip = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].zip"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].zip"]
+
+        return is_same_street and is_same_city and is_same_state and is_same_zip
+
+
+
+
+
+    def _remove_duplicate_residences(self):
+        """
+        Remove duplicate residences
+        if the borrower's residence is the same as the coborrowers residence
+        Part of ticket [FTR] CC-01
+        """
+        if self._address_validator():
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressStreetLine1")
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressState")
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressPostalCode")
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressCity")
+
+
+
     # Instance methods
     def get_projection(self):
         """Generate the projection for the given manifest.
@@ -361,6 +404,7 @@ class JSONFactory:
 
         """
         queries, record = [], {}
+        self._remove_duplicate_residences()
         for path, value in self._manifest:
 
             # Prioritize non-queries before queries

--- a/service/models.py
+++ b/service/models.py
@@ -350,6 +350,57 @@ class JSONFactory:
     def __init__(self, manifest: JSONManifest):
         self._manifest = manifest
 
+       #Added Code
+
+    def _address_validator(self):
+        """
+        This method compares the borrower and co-borrowers residence addresses.
+        It checks if the residence addresses are the same.
+        The residence addresses are the same if the street, city, state, and zip are the same.
+        """
+        borrower = 0
+        coborrower = 1
+        is_same_street = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].street"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].street"]
+
+        is_same_city = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].city"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].city"]
+
+        is_same_state = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].state"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].state"]
+
+        is_same_zip = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].zip"] \
+        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].zip"]
+
+        return is_same_street and is_same_city and is_same_state and is_same_zip
+
+
+    def _remove_duplicate_residences(self):
+        """
+        Remove duplicate residences before generating residence reports
+        if the borrower's residence is the same as the coborrowers residence
+        Part of ticket [FTR] CC-01
+        """
+        if self._address_validator():
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressStreetLine1")
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressState")
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressPostalCode")
+            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressCity")
+
+    def _create_shared_address_flag(self):
+        """
+        This method creates a new flag called "shared_address" to determine if the borrower and coborrower share
+        the same address. This method depends on the address_validator method from ticket [FTR] CC-01
+        to determine if the borrower and coborrower live together.
+        The borrower and coborrower live together if they both share the same address
+        """
+        if self._address_validator():
+            self._manifest._fdata.__setitem__(f"$.reports[?(@.title == 'Borrowers Report')].shared_address", True)
+        else:
+            self._manifest._fdata.__setitem__(f"$.reports[?(@.title == 'Borrowers Report')].shared_address", False)
+
+
+
     # Instance methods
     def get_projection(self):
         """Generate the projection for the given manifest.
@@ -361,6 +412,9 @@ class JSONFactory:
 
         """
         queries, record = [], {}
+        #call these methods before generatring report
+        self._create_shared_address_flag()
+        self._remove_duplicate_residences()
         for path, value in self._manifest:
 
             # Prioritize non-queries before queries

--- a/service/models.py
+++ b/service/models.py
@@ -354,30 +354,24 @@ class JSONFactory:
 
     #Added Code
 
-
     def _address_validator(self):
         """
-        This method compares the borrower and co-borrowers residence addresses.
+        This method compares the borrower's and co-borrower's residence addresses.
         It checks if the residence addresses are the same.
         The residence addresses are the same if the street, city, state, and zip are the same.
         """
-        borrower = 0
-        coborrower = 1
-        is_same_street = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].street"] \
-        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].street"]
+        data_length = len(self._manifest.data['applications'])
 
-        is_same_city = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].city"] \
-        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].city"]
-
-        is_same_state = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].state"] \
-        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].state"]
-
-        is_same_zip = self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{borrower}].zip"] \
-        == self._manifest.items[f"$.reports[?(@.title == 'Residences Report')].residences[{coborrower}].zip"]
-
-        return is_same_street and is_same_city and is_same_state and is_same_zip
-
-
+        for i in range(data_length):
+            is_same_street = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressStreetLine1") \
+            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressStreetLine1")
+            is_same_state = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressState") \
+            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressState")
+            is_same_city = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressCity") \
+            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressCity")
+            is_same_zip = self._manifest._fdata.get(f"$.applications[{i}].borrower.mailingAddress.addressPostalCode") \
+            == self._manifest._fdata.get(f"$.applications[{i}].coborrower.mailingAddress.addressPostalCode")
+        return is_same_street and is_same_state and is_same_city and is_same_zip
 
 
 
@@ -388,11 +382,13 @@ class JSONFactory:
         if the borrower's residence is the same as the coborrowers residence
         Part of ticket [FTR] CC-01
         """
-        if self._address_validator():
-            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressStreetLine1")
-            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressState")
-            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressPostalCode")
-            self._manifest._fdata.pop("$.applications[0].coborrower.mailingAddress.addressCity")
+        data_length = len(self._manifest.data['applications'])
+        for i in range(data_length):
+            if self._address_validator():
+                self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressStreetLine1")
+                self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressState")
+                self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressPostalCode")
+                self._manifest._fdata.pop(f"$.applications[{i}].coborrower.mailingAddress.addressCity")
 
 
 
@@ -411,6 +407,7 @@ class JSONFactory:
 
 
 
+
     # Instance methods
     def get_projection(self):
         """Generate the projection for the given manifest.
@@ -422,14 +419,10 @@ class JSONFactory:
 
         """
         queries, record = [], {}
-
-
-        #call these methods before generatring report
+        #call these methods before generating projection
         self._create_shared_address_flag()
-
         self._remove_duplicate_residences()
         for path, value in self._manifest:
-
             # Prioritize non-queries before queries
             if '?' in path:
                 queries.append((path, value))
@@ -439,5 +432,6 @@ class JSONFactory:
 
         for path, value in queries:
             self.insert_query(path, value, record)
+
 
         return record

--- a/tests/loandata.json
+++ b/tests/loandata.json
@@ -68,8 +68,8 @@
         },
         {
           "borrower": {
-            "firstName": "Jack",
-            "lastName": "Doe",
+            "firstName": "JACK",
+            "lastName": "DOE",
             "mailingAddress": {
               "addressStreetLine1": "555 PARK AVE.",
               "addressCity": "DALLAS",
@@ -78,8 +78,8 @@
             }
           },
           "coborrower": {
-            "firstName": "Jill",
-            "lastName": "Doe",
+            "firstName": "JILL",
+            "lastName": "DOE",
             "mailingAddress": {
               "addressStreetLine1": "123 PARK AVE.",
               "addressCity": "DALLAS",
@@ -90,8 +90,8 @@
         },
         {
           "borrower": {
-            "firstName": "John",
-            "lastName": "Smith",
+            "firstName": "JOHN",
+            "lastName": "SMITH",
             "mailingAddress": {
               "addressStreetLine1": "249 CENTRAL PKWY",
               "addressCity": "NEW YORK CITY",
@@ -100,8 +100,8 @@
             }
           },
           "coborrower": {
-            "firstName": "Jane",
-            "lastName": "Smith",
+            "firstName": "JANE",
+            "lastName": "SMITH",
             "mailingAddress": {
               "addressStreetLine1": "249 CENTRAL PKWY",
               "addressCity": "NEW YORK CITY",
@@ -113,8 +113,8 @@
         },
         {
           "borrower": {
-            "firstName": "Bruce",
-            "lastName": "Wayne",
+            "firstName": "BRUCE",
+            "lastName": "WAYNE",
             "mailingAddress": {
               "addressStreetLine1": "155 GOTHAM ST",
               "addressCity": "GOTHAM",
@@ -123,8 +123,8 @@
             }
           },
           "coborrower": {
-            "firstName": "Clark",
-            "lastName": "Kent",
+            "firstName": "CLARK",
+            "lastName": "KENT",
             "mailingAddress": {
               "addressStreetLine1": "222 METRO ST",
               "addressCity": "METROPOLIS",
@@ -135,8 +135,8 @@
         },
         {
           "borrower": {
-            "firstName": "Tony",
-            "lastName": "Stark",
+            "firstName": "TONY",
+            "lastName": "STARK",
             "mailingAddress": {
               "addressStreetLine1": "255 STARK ST",
               "addressCity": "NEW YORK CITY",
@@ -145,8 +145,8 @@
             }
           },
           "coborrower": {
-            "firstName": "Peter",
-            "lastName": "Parker",
+            "firstName": "PETER",
+            "lastName": "PARKER",
             "mailingAddress": {
               "addressStreetLine1": "955 QUEENS ST",
               "addressCity": "NEW YORK CITY",
@@ -157,8 +157,8 @@
         },
         {
           "borrower": {
-            "firstName": "Sherlock",
-            "lastName": "Holmes",
+            "firstName": "SHERLOCK",
+            "lastName": "HOLMES",
             "mailingAddress": {
               "addressStreetLine1": "221B BAKER STREET",
               "addressCity": "LONDON",
@@ -167,8 +167,8 @@
             }
           },
           "coborrower": {
-            "firstName": "John",
-            "lastName": "Watson",
+            "firstName": "JOHN",
+            "lastName": "WATSON",
             "mailingAddress": {
               "addressStreetLine1": "221B BAKER STREET",
               "addressCity": "LONDON",
@@ -179,8 +179,8 @@
         },
         {
           "borrower": {
-            "firstName": "Jack",
-            "lastName": "Smith",
+            "firstName": "JACK",
+            "lastName": "SMITH",
             "mailingAddress": {
               "addressStreetLine1": "111 KINGS ST",
               "addressCity": "NEW YORK CITY",
@@ -189,8 +189,8 @@
             }
           },
           "coborrower": {
-            "firstName": "Jill",
-            "lastName": "Smith",
+            "firstName": "JILL",
+            "lastName": "SMITH",
             "mailingAddress": {
               "addressStreetLine1": "111 KINGS ST",
               "addressCity": "NEW YORK CITY",
@@ -201,8 +201,8 @@
         },
         {
           "borrower": {
-            "firstName": "Robert",
-            "lastName": "Johnson",
+            "firstName": "ROBERT",
+            "lastName": "JOHNSON",
             "mailingAddress": {
               "addressStreetLine1": "117 HARRISON AVE",
               "addressCity": "JERSEY CITY",
@@ -211,8 +211,8 @@
             }
           },
           "coborrower": {
-            "firstName": "Paul",
-            "lastName": "Morrison",
+            "firstName": "PAUL",
+            "lastName": "MORRISON",
             "mailingAddress": {
               "addressStreetLine1": "275 JOHNSON ST",
               "addressCity": "PHILADELPHIA",
@@ -223,8 +223,8 @@
         },
         {
           "borrower": {
-            "firstName": "Alexander",
-            "lastName": "Hamilton",
+            "firstName": "ALEXANDER",
+            "lastName": "HAMILTON",
             "mailingAddress": {
               "addressStreetLine1": "555 HAMILTON ST",
               "addressCity": "NEW YORK CITY",
@@ -233,8 +233,8 @@
             }
           },
           "coborrower": {
-            "firstName": "John",
-            "lastName": "Laurens",
+            "firstName": "JOHN",
+            "lastName": "LAURENS",
             "mailingAddress": {
               "addressStreetLine1": "555 HAMILTON ST",
               "addressCity": "NEW YORK CITY",
@@ -245,8 +245,8 @@
         },
         {
           "borrower": {
-            "firstName": "George",
-            "lastName": "Washington",
+            "firstName": "GEORGE",
+            "lastName": "WASHINGTON",
             "mailingAddress": {
               "addressStreetLine1": "125 WILLIAMS ST",
               "addressCity": "WILLIAMSBURG",
@@ -255,8 +255,8 @@
             }
           },
           "coborrower": {
-            "firstName": "Abraham",
-            "lastName": "Lincoln",
+            "firstName": "ABRAHAM",
+            "lastName": "LINCOLN",
             "mailingAddress": {
               "addressStreetLine1": "155 CHERRYTREE ST",
               "addressCity": "CHICAGO",
@@ -267,8 +267,8 @@
         },
         {
           "borrower": {
-            "firstName": "Alan",
-            "lastName": "Turing",
+            "firstName": "ALAN",
+            "lastName": "TURING",
             "mailingAddress": {
               "addressStreetLine1": "915 EUCLID AVE",
               "addressCity": "PRINCETON",
@@ -277,8 +277,8 @@
             }
           },
           "coborrower": {
-            "firstName": "Albert",
-            "lastName": "Einstein",
+            "firstName": "ALBERT",
+            "lastName": "EINSTEIN",
             "mailingAddress": {
               "addressStreetLine1": "915 EUCLID AVE",
               "addressCity": "PRINCETON",
@@ -289,8 +289,8 @@
         },
         {
           "borrower": {
-            "firstName": "Elon",
-            "lastName": "Musk",
+            "firstName": "ELON",
+            "lastName": "MUSK",
             "mailingAddress": {
               "addressStreetLine1": "999 ROCKET ST",
               "addressCity": "AUSTIN",
@@ -299,8 +299,8 @@
             }
           },
           "coborrower": {
-            "firstName": "Larry",
-            "lastName": "Page",
+            "firstName": "LARRY",
+            "lastName": "PAGE",
             "mailingAddress": {
               "addressStreetLine1": "314 MOUNTAIN AVE",
               "addressCity": "MOUNTAIN VIEW",
@@ -311,8 +311,8 @@
         },
         {
           "borrower": {
-            "firstName": "Lebron",
-            "lastName": "James",
+            "firstName": "LEBRON",
+            "lastName": "JAMES",
             "mailingAddress": {
               "addressStreetLine1": "815 SUNFLOWER AVE",
               "addressCity": "LOS ANGELES",
@@ -321,8 +321,8 @@
             }
           },
           "coborrower": {
-            "firstName": "Michael",
-            "lastName": "Jordan",
+            "firstName": "MICHAEL",
+            "lastName": "JORDAN",
             "mailingAddress": {
               "addressStreetLine1": "815 SUNFLOWER AVE",
               "addressCity": "LOS ANGELES",
@@ -333,8 +333,8 @@
         },
         {
           "borrower": {
-            "firstName": "Thomas",
-            "lastName": "Edison",
+            "firstName": "THOMAS",
+            "lastName": "EDISON",
             "mailingAddress": {
               "addressStreetLine1": "199 GLENMONT AVE",
               "addressCity": "WEST ORANGE",
@@ -343,8 +343,8 @@
             }
           },
           "coborrower": {
-            "firstName": "Nikola",
-            "lastName": "Tesla",
+            "firstName": "NIKOLA",
+            "lastName": "TESLA",
             "mailingAddress": {
               "addressStreetLine1": "481 8TH AVE",
               "addressCity": "NEW YORK CITY",

--- a/tests/loandata.json
+++ b/tests/loandata.json
@@ -21,7 +21,339 @@
                     "addressPostalCode": "75028"
                 }
             }
+        },
+        {
+          "borrower": {
+              "firstName": "LUKE",
+              "lastName": "SKYWALKER",
+              "mailingAddress": {
+                  "addressStreetLine1": "246 EXAMPLE PKWY.",
+                  "addressCity": "TOWER MOUND",
+                  "addressState": "TX",
+                  "addressPostalCode": "75028"
+              }
+          },
+          "coborrower": {
+              "firstName": "DARTH",
+              "lastName": "VADER",
+              "mailingAddress": {
+                  "addressStreetLine1": "891 EXAMPLE PKWY.",
+                  "addressCity": "TOWER MOUND",
+                  "addressState": "TX",
+                  "addressPostalCode": "75028"
+              }
+          }
+        },
+        {
+          "borrower": {
+              "firstName": "BILL",
+              "lastName": "GATES",
+              "mailingAddress": {
+                  "addressStreetLine1": "123 STAR AVE.",
+                  "addressCity": "HOLLYWOOD",
+                  "addressState": "CA",
+                  "addressPostalCode": "55228"
+              }
+          },
+          "coborrower": {
+              "firstName": "STEVE",
+              "lastName": "JOBS",
+              "mailingAddress": {
+                  "addressStreetLine1": "123 STAR AVE.",
+                  "addressCity": "HOLLYWOOD",
+                  "addressState": "CA",
+                  "addressPostalCode": "55228"
+              }
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "Jack",
+            "lastName": "Doe",
+            "mailingAddress": {
+              "addressStreetLine1": "555 PARK AVE.",
+              "addressCity": "DALLAS",
+              "addressState": "TX",
+              "addressPostalCode": "98289"
+            }
+          },
+          "coborrower": {
+            "firstName": "Jill",
+            "lastName": "Doe",
+            "mailingAddress": {
+              "addressStreetLine1": "123 PARK AVE.",
+              "addressCity": "DALLAS",
+              "addressState": "TX",
+              "addressPostalCode": "98289"
+            }
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "John",
+            "lastName": "Smith",
+            "mailingAddress": {
+              "addressStreetLine1": "249 CENTRAL PKWY",
+              "addressCity": "NEW YORK CITY",
+              "addressState": "NY",
+              "addressPostalCode": "10025"
+            }
+          },
+          "coborrower": {
+            "firstName": "Jane",
+            "lastName": "Smith",
+            "mailingAddress": {
+              "addressStreetLine1": "249 CENTRAL PKWY",
+              "addressCity": "NEW YORK CITY",
+              "addressState": "NY",
+              "addressPostalCode": "10025"
+            }
+
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "Bruce",
+            "lastName": "Wayne",
+            "mailingAddress": {
+              "addressStreetLine1": "155 GOTHAM ST",
+              "addressCity": "GOTHAM",
+              "addressState": "FICTIONAL STATE",
+              "addressPostalCode": "50025"
+            }
+          },
+          "coborrower": {
+            "firstName": "Clark",
+            "lastName": "Kent",
+            "mailingAddress": {
+              "addressStreetLine1": "222 METRO ST",
+              "addressCity": "METROPOLIS",
+              "addressState": "FICTIONAL STATE",
+              "addressPostalCode": "59955"
+            }
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "Tony",
+            "lastName": "Stark",
+            "mailingAddress": {
+              "addressStreetLine1": "255 STARK ST",
+              "addressCity": "NEW YORK CITY",
+              "addressState": "NY",
+              "addressPostalCode": "50025"
+            }
+          },
+          "coborrower": {
+            "firstName": "Peter",
+            "lastName": "Parker",
+            "mailingAddress": {
+              "addressStreetLine1": "955 QUEENS ST",
+              "addressCity": "NEW YORK CITY",
+              "addressState": "NY",
+              "addressPostalCode": "59955"
+            }
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "Sherlock",
+            "lastName": "Holmes",
+            "mailingAddress": {
+              "addressStreetLine1": "221B BAKER STREET",
+              "addressCity": "LONDON",
+              "addressState": "UK",
+              "addressPostalCode": "40521"
+            }
+          },
+          "coborrower": {
+            "firstName": "John",
+            "lastName": "Watson",
+            "mailingAddress": {
+              "addressStreetLine1": "221B BAKER STREET",
+              "addressCity": "LONDON",
+              "addressState": "UK",
+              "addressPostalCode": "40521"
+            }
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "Jack",
+            "lastName": "Smith",
+            "mailingAddress": {
+              "addressStreetLine1": "111 KINGS ST",
+              "addressCity": "NEW YORK CITY",
+              "addressState": "NY",
+              "addressPostalCode": "10089"
+            }
+          },
+          "coborrower": {
+            "firstName": "Jill",
+            "lastName": "Smith",
+            "mailingAddress": {
+              "addressStreetLine1": "111 KINGS ST",
+              "addressCity": "NEW YORK CITY",
+              "addressState": "NY",
+              "addressPostalCode": "10089"
+            }
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "Robert",
+            "lastName": "Johnson",
+            "mailingAddress": {
+              "addressStreetLine1": "117 HARRISON AVE",
+              "addressCity": "JERSEY CITY",
+              "addressState": "NJ",
+              "addressPostalCode": "39045"
+            }
+          },
+          "coborrower": {
+            "firstName": "Paul",
+            "lastName": "Morrison",
+            "mailingAddress": {
+              "addressStreetLine1": "275 JOHNSON ST",
+              "addressCity": "PHILADELPHIA",
+              "addressState": "PA",
+              "addressPostalCode": "95928"
+            }
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "Alexander",
+            "lastName": "Hamilton",
+            "mailingAddress": {
+              "addressStreetLine1": "555 HAMILTON ST",
+              "addressCity": "NEW YORK CITY",
+              "addressState": "NY",
+              "addressPostalCode": "10055"
+            }
+          },
+          "coborrower": {
+            "firstName": "John",
+            "lastName": "Laurens",
+            "mailingAddress": {
+              "addressStreetLine1": "555 HAMILTON ST",
+              "addressCity": "NEW YORK CITY",
+              "addressState": "NY",
+              "addressPostalCode": "10055"
+            }
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "George",
+            "lastName": "Washington",
+            "mailingAddress": {
+              "addressStreetLine1": "125 WILLIAMS ST",
+              "addressCity": "WILLIAMSBURG",
+              "addressState": "VA",
+              "addressPostalCode": "50025"
+            }
+          },
+          "coborrower": {
+            "firstName": "Abraham",
+            "lastName": "Lincoln",
+            "mailingAddress": {
+              "addressStreetLine1": "155 CHERRYTREE ST",
+              "addressCity": "CHICAGO",
+              "addressState": "IL",
+              "addressPostalCode": "29955"
+            }
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "Alan",
+            "lastName": "Turing",
+            "mailingAddress": {
+              "addressStreetLine1": "915 EUCLID AVE",
+              "addressCity": "PRINCETON",
+              "addressState": "NJ",
+              "addressPostalCode": "12005"
+            }
+          },
+          "coborrower": {
+            "firstName": "Albert",
+            "lastName": "Einstein",
+            "mailingAddress": {
+              "addressStreetLine1": "915 EUCLID AVE",
+              "addressCity": "PRINCETON",
+              "addressState": "NJ",
+              "addressPostalCode": "12005"
+            }
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "Elon",
+            "lastName": "Musk",
+            "mailingAddress": {
+              "addressStreetLine1": "999 ROCKET ST",
+              "addressCity": "AUSTIN",
+              "addressState": "TX",
+              "addressPostalCode": "50025"
+            }
+          },
+          "coborrower": {
+            "firstName": "Larry",
+            "lastName": "Page",
+            "mailingAddress": {
+              "addressStreetLine1": "314 MOUNTAIN AVE",
+              "addressCity": "MOUNTAIN VIEW",
+              "addressState": "CA",
+              "addressPostalCode": "49815"
+            }
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "Lebron",
+            "lastName": "James",
+            "mailingAddress": {
+              "addressStreetLine1": "815 SUNFLOWER AVE",
+              "addressCity": "LOS ANGELES",
+              "addressState": "CA",
+              "addressPostalCode": "22845"
+            }
+          },
+          "coborrower": {
+            "firstName": "Michael",
+            "lastName": "Jordan",
+            "mailingAddress": {
+              "addressStreetLine1": "815 SUNFLOWER AVE",
+              "addressCity": "LOS ANGELES",
+              "addressState": "CA",
+              "addressPostalCode": "22845"
+            }
+          }
+        },
+        {
+          "borrower": {
+            "firstName": "Thomas",
+            "lastName": "Edison",
+            "mailingAddress": {
+              "addressStreetLine1": "199 GLENMONT AVE",
+              "addressCity": "WEST ORANGE",
+              "addressState": "NJ",
+              "addressPostalCode": "11255"
+            }
+          },
+          "coborrower": {
+            "firstName": "Nikola",
+            "lastName": "Tesla",
+            "mailingAddress": {
+              "addressStreetLine1": "481 8TH AVE",
+              "addressCity": "NEW YORK CITY",
+              "addressState": "NY",
+              "addressPostalCode": "10099"
+            }
+          }
         }
+
     ],
     "property": {
         "streetAddress": "456 NEW HOME CT.",

--- a/tests/reports.json
+++ b/tests/reports.json
@@ -8,12 +8,6 @@
           "city": "FLOWER MOUND",
           "state": "TX",
           "zip": "75028"
-        },
-        {
-          "street": "123 EXAMPLE PKWY.",
-          "city": "FLOWER MOUND",
-          "state": "TX",
-          "zip": "75028"
         }
       ]
     },

--- a/tests/reports.json
+++ b/tests/reports.json
@@ -8,6 +8,152 @@
           "city": "FLOWER MOUND",
           "state": "TX",
           "zip": "75028"
+        },
+        {},
+        {
+          "street": "246 EXAMPLE PKWY.",
+          "state": "TX",
+          "city": "TOWER MOUND",
+          "zip": "75028"
+        },
+        {
+          "street": "891 EXAMPLE PKWY.",
+          "state": "TX",
+          "city": "TOWER MOUND",
+          "zip": "75028"
+        },
+        {
+          "street": "123 STAR AVE.",
+          "state": "CA",
+          "city": "HOLLYWOOD",
+          "zip": "55228"
+        },
+        {},
+        {
+          "street": "555 PARK AVE.",
+          "state": "TX",
+          "city": "DALLAS",
+          "zip": "98289"
+        },
+        {
+          "street": "123 PARK AVE.",
+          "state": "TX",
+          "city": "DALLAS",
+          "zip": "98289"
+        },
+        {
+          "street": "249 CENTRAL PKWY",
+          "state": "NY",
+          "city": "NEW YORK CITY",
+          "zip": "10025"
+        },
+        {},
+        {
+          "street": "155 GOTHAM ST",
+          "state": "FICTIONAL STATE",
+          "city": "GOTHAM",
+          "zip": "50025"
+        },
+        {
+          "street": "222 METRO ST",
+          "state": "FICTIONAL STATE",
+          "city": "METROPOLIS",
+          "zip": "59955"
+        },
+        {
+          "street": "255 STARK ST",
+          "state": "NY",
+          "city": "NEW YORK CITY",
+          "zip": "50025"
+        },
+        {
+          "street": "955 QUEENS ST",
+          "state": "NY",
+          "city": "NEW YORK CITY",
+          "zip": "59955"
+        },
+        {
+          "street": "221B BAKER STREET",
+          "state": "UK",
+          "city": "LONDON",
+          "zip": "40521"
+        },
+        {},
+        {
+          "street": "111 KINGS ST",
+          "state": "NY",
+          "city": "NEW YORK CITY",
+          "zip": "10089"
+        },
+        {},
+        {
+          "street": "117 HARRISON AVE",
+          "state": "NJ",
+          "city": "JERSEY CITY",
+          "zip": "39045"
+        },
+        {
+          "street": "275 JOHNSON ST",
+          "state": "PA",
+          "city": "PHILADELPHIA",
+          "zip": "95928"
+        },
+        {
+          "street": "555 HAMILTON ST",
+          "state": "NY",
+          "city": "NEW YORK CITY",
+          "zip": "10055"
+        },
+        {},
+        {
+          "street": "125 WILLIAMS ST",
+          "state": "VA",
+          "city": "WILLIAMSBURG",
+          "zip": "50025"
+        },
+        {
+          "street": "155 CHERRYTREE ST",
+          "state": "IL",
+          "city": "CHICAGO",
+          "zip": "29955"
+        },
+        {
+          "street": "915 EUCLID AVE",
+          "state": "NJ",
+          "city": "PRINCETON",
+          "zip": "12005"
+        },
+        {},
+        {
+          "street": "999 ROCKET ST",
+          "state": "TX",
+          "city": "AUSTIN",
+          "zip": "50025"
+        },
+        {
+          "street": "314 MOUNTAIN AVE",
+          "state": "CA",
+          "city": "MOUNTAIN VIEW",
+          "zip": "49815"
+        },
+        {
+          "street": "815 SUNFLOWER AVE",
+          "state": "CA",
+          "city": "LOS ANGELES",
+          "zip": "22845"
+        },
+        {},
+        {
+          "street": "199 GLENMONT AVE",
+          "state": "NJ",
+          "city": "WEST ORANGE",
+          "zip": "11255"
+        },
+        {
+          "street": "481 8TH AVE",
+          "state": "NY",
+          "city": "NEW YORK CITY",
+          "zip": "10099"
         }
       ]
     },
@@ -21,9 +167,128 @@
         {
           "first_name": "JOHN",
           "last_name": "DOE"
+        },
+        {
+          "first_name": "LUKE",
+          "last_name": "SKYWALKER"
+        },
+        {
+          "first_name": "DARTH",
+          "last_name": "VADER"
+        },
+        {
+          "first_name": "BILL",
+          "last_name": "GATES"
+        },
+        {
+          "first_name": "STEVE",
+          "last_name": "JOBS"
+        },
+        {
+          "first_name": "Jack",
+          "last_name": "Doe"
+        },
+        {
+          "first_name": "Jill",
+          "last_name": "Doe"
+        },
+        {
+          "first_name": "John",
+          "last_name": "Smith"
+        },
+        {
+          "first_name": "Jane",
+          "last_name": "Smith"
+        },
+        {
+          "first_name": "Bruce",
+          "last_name": "Wayne"
+        },
+        {
+          "first_name": "Clark",
+          "last_name": "Kent"
+        },
+        {
+          "first_name": "Tony",
+          "last_name": "Stark"
+        },
+        {
+          "first_name": "Peter",
+          "last_name": "Parker"
+        },
+        {
+          "first_name": "Sherlock",
+          "last_name": "Holmes"
+        },
+        {
+          "first_name": "John",
+          "last_name": "Watson"
+        },
+        {
+          "first_name": "Jack",
+          "last_name": "Smith"
+        },
+        {
+          "first_name": "Jill",
+          "last_name": "Smith"
+        },
+        {
+          "first_name": "Robert",
+          "last_name": "Johnson"
+        },
+        {
+          "first_name": "Paul",
+          "last_name": "Morrison"
+        },
+        {
+          "first_name": "Alexander",
+          "last_name": "Hamilton"
+        },
+        {
+          "first_name": "John",
+          "last_name": "Laurens"
+        },
+        {
+          "first_name": "George",
+          "last_name": "Washington"
+        },
+        {
+          "first_name": "Abraham",
+          "last_name": "Lincoln"
+        },
+        {
+          "first_name": "Alan",
+          "last_name": "Turing"
+        },
+        {
+          "first_name": "Albert",
+          "last_name": "Einstein"
+        },
+        {
+          "first_name": "Elon",
+          "last_name": "Musk"
+        },
+        {
+          "first_name": "Larry",
+          "last_name": "Page"
+        },
+        {
+          "first_name": "Lebron",
+          "last_name": "James"
+        },
+        {
+          "first_name": "Michael",
+          "last_name": "Jordan"
+        },
+        {
+          "first_name": "Thomas",
+          "last_name": "Edison"
+        },
+        {
+          "first_name": "Nikola",
+          "last_name": "Tesla"
         }
-      ],
-      "shared_address": true
+      ]
     }
   ]
 }

--- a/tests/reports.json
+++ b/tests/reports.json
@@ -185,108 +185,108 @@
           "last_name": "JOBS"
         },
         {
-          "first_name": "Jack",
-          "last_name": "Doe"
+          "first_name": "JACK",
+          "last_name": "DOE"
         },
         {
-          "first_name": "Jill",
-          "last_name": "Doe"
+          "first_name": "JILL",
+          "last_name": "DOE"
         },
         {
-          "first_name": "John",
-          "last_name": "Smith"
+          "first_name": "JOHN",
+          "last_name": "SMITH"
         },
         {
-          "first_name": "Jane",
-          "last_name": "Smith"
+          "first_name": "JANE",
+          "last_name": "SMITH"
         },
         {
-          "first_name": "Bruce",
-          "last_name": "Wayne"
+          "first_name": "BRUCE",
+          "last_name": "WAYNE"
         },
         {
-          "first_name": "Clark",
-          "last_name": "Kent"
+          "first_name": "CLARK",
+          "last_name": "KENT"
         },
         {
-          "first_name": "Tony",
-          "last_name": "Stark"
+          "first_name": "TONY",
+          "last_name": "STARK"
         },
         {
-          "first_name": "Peter",
-          "last_name": "Parker"
+          "first_name": "PETER",
+          "last_name": "PARKER"
         },
         {
-          "first_name": "Sherlock",
-          "last_name": "Holmes"
+          "first_name": "SHERLOCK",
+          "last_name": "HOLMES"
         },
         {
-          "first_name": "John",
-          "last_name": "Watson"
+          "first_name": "JOHN",
+          "last_name": "WATSON"
         },
         {
-          "first_name": "Jack",
-          "last_name": "Smith"
+          "first_name": "JACK",
+          "last_name": "SMITH"
         },
         {
-          "first_name": "Jill",
-          "last_name": "Smith"
+          "first_name": "JILL",
+          "last_name": "SMITH"
         },
         {
-          "first_name": "Robert",
-          "last_name": "Johnson"
+          "first_name": "ROBERT",
+          "last_name": "JOHNSON"
         },
         {
-          "first_name": "Paul",
-          "last_name": "Morrison"
+          "first_name": "PAUL",
+          "last_name": "MORRISON"
         },
         {
-          "first_name": "Alexander",
-          "last_name": "Hamilton"
+          "first_name": "ALEXANDER",
+          "last_name": "HAMILTON"
         },
         {
-          "first_name": "John",
-          "last_name": "Laurens"
+          "first_name": "JOHN",
+          "last_name": "LAURENS"
         },
         {
-          "first_name": "George",
-          "last_name": "Washington"
+          "first_name": "GEORGE",
+          "last_name": "WASHINGTON"
         },
         {
-          "first_name": "Abraham",
-          "last_name": "Lincoln"
+          "first_name": "ABRAHAM",
+          "last_name": "LINCOLN"
         },
         {
-          "first_name": "Alan",
-          "last_name": "Turing"
+          "first_name": "ALAN",
+          "last_name": "TURING"
         },
         {
-          "first_name": "Albert",
-          "last_name": "Einstein"
+          "first_name": "ALBERT",
+          "last_name": "EINSTEIN"
         },
         {
-          "first_name": "Elon",
-          "last_name": "Musk"
+          "first_name": "ELON",
+          "last_name": "MUSK"
         },
         {
-          "first_name": "Larry",
-          "last_name": "Page"
+          "first_name": "LARRY",
+          "last_name": "PAGE"
         },
         {
-          "first_name": "Lebron",
-          "last_name": "James"
+          "first_name": "LEBRON",
+          "last_name": "JAMES"
         },
         {
-          "first_name": "Michael",
-          "last_name": "Jordan"
+          "first_name": "MICHAEL",
+          "last_name": "JORDAN"
         },
         {
-          "first_name": "Thomas",
-          "last_name": "Edison"
+          "first_name": "THOMAS",
+          "last_name": "EDISON"
         },
         {
-          "first_name": "Nikola",
-          "last_name": "Tesla"
+          "first_name": "NIKOLA",
+          "last_name": "TESLA"
         }
       ]
     }

--- a/tests/reports.json
+++ b/tests/reports.json
@@ -162,131 +162,163 @@
       "borrowers": [
         {
           "first_name": "JANE",
-          "last_name": "DOE"
+          "last_name": "DOE",
+          "shared_address": true
         },
         {
           "first_name": "JOHN",
-          "last_name": "DOE"
+          "last_name": "DOE",
+          "shared_address": true
         },
         {
           "first_name": "LUKE",
-          "last_name": "SKYWALKER"
+          "last_name": "SKYWALKER",
+          "shared_address": false
         },
         {
           "first_name": "DARTH",
-          "last_name": "VADER"
+          "last_name": "VADER",
+          "shared_address": false
         },
         {
           "first_name": "BILL",
-          "last_name": "GATES"
+          "last_name": "GATES",
+          "shared_address": true
         },
         {
           "first_name": "STEVE",
-          "last_name": "JOBS"
+          "last_name": "JOBS",
+          "shared_address": true
         },
         {
           "first_name": "JACK",
-          "last_name": "DOE"
+          "last_name": "DOE",
+          "shared_address": false
         },
         {
           "first_name": "JILL",
-          "last_name": "DOE"
+          "last_name": "DOE",
+          "shared_address": false
         },
         {
           "first_name": "JOHN",
-          "last_name": "SMITH"
+          "last_name": "SMITH",
+          "shared_address": true
         },
         {
           "first_name": "JANE",
-          "last_name": "SMITH"
+          "last_name": "SMITH",
+          "shared_address": true
         },
         {
           "first_name": "BRUCE",
-          "last_name": "WAYNE"
+          "last_name": "WAYNE",
+          "shared_address": false
         },
         {
           "first_name": "CLARK",
-          "last_name": "KENT"
+          "last_name": "KENT",
+          "shared_address": false
         },
         {
           "first_name": "TONY",
-          "last_name": "STARK"
+          "last_name": "STARK",
+          "shared_address": false
         },
         {
           "first_name": "PETER",
-          "last_name": "PARKER"
+          "last_name": "PARKER",
+          "shared_address": false
         },
         {
           "first_name": "SHERLOCK",
-          "last_name": "HOLMES"
+          "last_name": "HOLMES",
+          "shared_address": true
         },
         {
           "first_name": "JOHN",
-          "last_name": "WATSON"
+          "last_name": "WATSON",
+          "shared_address": true
         },
         {
           "first_name": "JACK",
-          "last_name": "SMITH"
+          "last_name": "SMITH",
+          "shared_address": true
         },
         {
           "first_name": "JILL",
-          "last_name": "SMITH"
+          "last_name": "SMITH",
+          "shared_address": true
         },
         {
           "first_name": "ROBERT",
-          "last_name": "JOHNSON"
+          "last_name": "JOHNSON",
+          "shared_address": false
         },
         {
           "first_name": "PAUL",
-          "last_name": "MORRISON"
+          "last_name": "MORRISON",
+          "shared_address": false
         },
         {
           "first_name": "ALEXANDER",
-          "last_name": "HAMILTON"
+          "last_name": "HAMILTON",
+          "shared_address": true
         },
         {
           "first_name": "JOHN",
-          "last_name": "LAURENS"
+          "last_name": "LAURENS",
+          "shared_address": true
         },
         {
           "first_name": "GEORGE",
-          "last_name": "WASHINGTON"
+          "last_name": "WASHINGTON",
+          "shared_address": false
         },
         {
           "first_name": "ABRAHAM",
-          "last_name": "LINCOLN"
+          "last_name": "LINCOLN",
+          "shared_address": false
         },
         {
           "first_name": "ALAN",
-          "last_name": "TURING"
+          "last_name": "TURING",
+          "shared_address": true
         },
         {
           "first_name": "ALBERT",
-          "last_name": "EINSTEIN"
+          "last_name": "EINSTEIN",
+          "shared_address": true
         },
         {
           "first_name": "ELON",
-          "last_name": "MUSK"
+          "last_name": "MUSK",
+          "shared_address": false
         },
         {
           "first_name": "LARRY",
-          "last_name": "PAGE"
+          "last_name": "PAGE",
+          "shared_address": false
         },
         {
           "first_name": "LEBRON",
-          "last_name": "JAMES"
+          "last_name": "JAMES",
+          "shared_address": true
         },
         {
           "first_name": "MICHAEL",
-          "last_name": "JORDAN"
+          "last_name": "JORDAN",
+          "shared_address": true
         },
         {
           "first_name": "THOMAS",
-          "last_name": "EDISON"
+          "last_name": "EDISON",
+          "shared_address": false
         },
         {
           "first_name": "NIKOLA",
-          "last_name": "TESLA"
+          "last_name": "TESLA",
+          "shared_address": false
         }
       ]
     }

--- a/tests/reports.json
+++ b/tests/reports.json
@@ -8,12 +8,6 @@
           "city": "FLOWER MOUND",
           "state": "TX",
           "zip": "75028"
-        },
-        {
-          "street": "123 EXAMPLE PKWY.",
-          "city": "FLOWER MOUND",
-          "state": "TX",
-          "zip": "75028"
         }
       ]
     },
@@ -28,7 +22,8 @@
           "first_name": "JOHN",
           "last_name": "DOE"
         }
-      ]
+      ],
+      "shared_address": true
     }
   ]
 }

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -3,6 +3,7 @@ import sys
 import json
 import logging
 
+
 # Initialize Logging
 for handler in logging.root.handlers[:]:
     logging.root.removeHandler(handler)
@@ -46,6 +47,7 @@ if __name__ == '__main__':
 
     with open('loandata.json') as file:
         event = generate_event(json.load(file))
+
     response = main(event)
 
     logger.info('Reports: %s', json.dumps(response, indent=2))


### PR DESCRIPTION
I created this branch to display the shared address flags for multiple borrowers. Each borrower and coborrower share the same shared address flag. The report displays multiple borrowers each with a shared address flag. It is important to note that the borrowers are indexed as even numbers and the coborrowers are indexed as odd numbers in the applications list. 