### PR TITLE
CC-01 [get unique address] & CC-02 [add shared_address field] for report completed

### DIFF
--- a/resources/borrowers.json
+++ b/resources/borrowers.json
@@ -14,5 +14,10 @@
     {
         "source": "$.applications[0].coborrower.lastName",
         "target": "$.reports[?(@.title == 'Borrowers Report')].borrowers[1].last_name"
+    },
+    {
+        "borrower_address": "$.applications[0].borrower.mailingAddress",
+        "coborrower_address": "$.applications[0].coborrower.mailingAddress",
+        "target": "$.reports[?(@.title == 'Borrowers Report')].shared_address"
     }
 ]

--- a/service/models.py
+++ b/service/models.py
@@ -70,9 +70,23 @@ class JSONManifest:
     def __iter__(self):
         """Iterate on the rules and items, yielding only those which match."""
         for rule in self._rules:
+            address = dict()
+            count_address = dict()
             for path, value in self._fdata.items():
                 if rule.get('source') == path:
                     yield rule.get('target'), value
+                elif 'borrower_address' in rule and 'coborrower_address' in rule:
+                    borrower_address = rule.get('borrower_address')
+                    coborrower_address = rule.get('coborrower_address')
+                    if coborrower_address in path or borrower_address in path:
+                        address_field = path.split('.')[-1]
+                        if address.get(address_field) and address.get(address_field) == value:
+                            count_address[address_field] = count_address[address_field] + 1
+                        else:
+                            count_address[address_field] = 1
+                            address[address_field] = value
+            if count_address:
+                yield rule.get('target'), all(val == 2 for val in count_address.values())
 
     # Static methods
     @staticmethod

--- a/service/models.py
+++ b/service/models.py
@@ -1,5 +1,6 @@
 """Service models and factories."""
 import re
+import json
 import logging
 from copy import copy
 from typing import Generator, List, Any
@@ -386,5 +387,13 @@ class JSONFactory:
 
         for path, value in queries:
             self.insert_query(path, value, record)
-
-        return record
+        
+        # filter unique residences
+        output = {'reports': []}
+        for rec in record['reports']:
+            if rec.get('residences') and isinstance(rec.get('residences'), list):
+                residences = set([json.dumps(res) for res in rec.get('residences')])
+                rec['residences'] = [json.loads(res) for res in residences]
+            output['reports'].append(rec)
+        
+        return output

--- a/tests/reports.json
+++ b/tests/reports.json
@@ -8,12 +8,6 @@
           "city": "FLOWER MOUND",
           "state": "TX",
           "zip": "75028"
-        },
-        {
-          "street": "123 EXAMPLE PKWY.",
-          "city": "FLOWER MOUND",
-          "state": "TX",
-          "zip": "75028"
         }
       ]
     },

--- a/tests/reports.json
+++ b/tests/reports.json
@@ -28,7 +28,8 @@
           "first_name": "JOHN",
           "last_name": "DOE"
         }
-      ]
+      ],
+      "shared_address": true
     }
   ]
 }


### PR DESCRIPTION
Approach - 
- Added `borrower_address` and `coborrower_address` in the mapping logic of borrowers.
- Added target as `shared_address` in the mapping logic.
- Updated `__iter__` function of `JSONManifest` to implement a custom logic to handle `borrower_address` and `coborrower_address` mapping rule.
- Updated `get_projection` function of `JSONFactory` to filter unique residences of each record before generating the report. 