### PR TITLE
[FTR] CC-01, CC-02, CC-03 Challenge  solution - Part 1

### DIFF
--- a/.aws-sam/temp-template.yaml
+++ b/.aws-sam/temp-template.yaml
@@ -1,0 +1,9 @@
+Resources:
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      Timeout: 300
+      MemorySize: 128
+      Handler: handler.main
+      CodeUri: C:\Users\shawn\code\autoferrit\python-challenge
+      Runtime: python3.8

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeProfile" value="profile:default" />
+    <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedProfiles">
+      <list>
+        <option value="profile:default" />
+      </list>
+    </option>
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-east-1" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,35 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="JSHint" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ourVersions">
+        <value>
+          <list size="2">
+            <item index="0" class="java.lang.String" itemvalue="3.9" />
+            <item index="1" class="java.lang.String" itemvalue="3.10" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyMissingOrEmptyDocstringInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyMissingTypeHintsInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="pbr" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyPep8NamingInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="N803" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="Default" />
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/markdown-navigator-enh.xml
+++ b/.idea/markdown-navigator-enh.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownEnhProjectSettings">
+    <AnnotatorSettings targetHasSpaces="true" linkCaseMismatch="true" wikiCaseMismatch="true" wikiLinkHasDashes="true" notUnderWikiHome="true" targetNotWikiPageExt="true" notUnderSourceWikiHome="true" targetNameHasAnchor="true" targetPathHasAnchor="true" wikiLinkHasSlash="true" wikiLinkHasSubdir="true" wikiLinkHasOnlyAnchor="true" linkTargetsWikiHasExt="true" linkTargetsWikiHasBadExt="true" notUnderSameRepo="true" targetNotUnderVcs="false" linkNeedsExt="true" linkHasBadExt="true" linkTargetNeedsExt="true" linkTargetHasBadExt="true" wikiLinkNotInWiki="true" imageTargetNotInRaw="true" repoRelativeAcrossVcsRoots="true" multipleWikiTargetsMatch="true" unresolvedLinkReference="true" linkIsIgnored="true" anchorIsIgnored="true" anchorIsUnresolved="true" anchorLineReferenceIsUnresolved="true" anchorLineReferenceFormat="true" anchorHasDuplicates="true" abbreviationDuplicates="true" abbreviationNotUsed="true" attributeIdDuplicateDefinition="true" attributeIdNotUsed="true" footnoteDuplicateDefinition="true" footnoteUnresolved="true" footnoteDuplicates="true" footnoteNotUsed="true" macroDuplicateDefinition="true" macroUnresolved="true" macroDuplicates="true" macroNotUsed="true" referenceDuplicateDefinition="true" referenceUnresolved="true" referenceDuplicates="true" referenceNotUsed="true" referenceUnresolvedNumericId="true" enumRefDuplicateDefinition="true" enumRefUnresolved="true" enumRefDuplicates="true" enumRefNotUsed="true" enumRefLinkUnresolved="true" enumRefLinkDuplicates="true" simTocUpdateNeeded="true" simTocTitleSpaceNeeded="true" />
+    <HtmlExportSettings updateOnSave="false" parentDir="" targetDir="" cssDir="css" scriptDir="js" plainHtml="false" imageDir="" copyLinkedImages="false" imagePathType="0" targetPathType="2" targetExt="" useTargetExt="false" noCssNoScripts="false" useElementStyleAttribute="false" linkToExportedHtml="true" exportOnSettingsChange="true" regenerateOnProjectOpen="false" linkFormatType="HTTP_ABSOLUTE" />
+    <LinkMapSettings>
+      <textMaps />
+    </LinkMapSettings>
+  </component>
+</project>

--- a/.idea/markdown-navigator.xml
+++ b/.idea/markdown-navigator.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownProjectSettings">
+    <PreviewSettings splitEditorLayout="SPLIT" splitEditorPreview="PREVIEW" useGrayscaleRendering="false" zoomFactor="1.5" maxImageWidth="0" synchronizePreviewPosition="true" highlightPreviewType="LINE" highlightFadeOut="5" highlightOnTyping="true" synchronizeSourcePosition="true" verticallyAlignSourceAndPreviewSyncPosition="true" showSearchHighlightsInPreview="true" showSelectionInPreview="true" lastLayoutSetsDefault="false">
+      <PanelProvider>
+        <provider providerId="com.vladsch.md.nav.editor.jbcef.html.panel" providerName="Java Chromium Embedded" />
+      </PanelProvider>
+    </PreviewSettings>
+    <ParserSettings gitHubSyntaxChange="false" correctedInvalidSettings="false" emojiShortcuts="1" emojiImages="0">
+      <PegdownExtensions>
+        <option name="ATXHEADERSPACE" value="true" />
+        <option name="FENCED_CODE_BLOCKS" value="true" />
+        <option name="INTELLIJ_DUMMY_IDENTIFIER" value="true" />
+        <option name="RELAXEDHRULES" value="true" />
+        <option name="STRIKETHROUGH" value="true" />
+        <option name="TABLES" value="true" />
+        <option name="TASKLISTITEMS" value="true" />
+      </PegdownExtensions>
+      <ParserOptions>
+        <option name="COMMONMARK_LISTS" value="true" />
+        <option name="EMOJI_SHORTCUTS" value="true" />
+        <option name="GFM_TABLE_RENDERING" value="true" />
+        <option name="PRODUCTION_SPEC_PARSER" value="true" />
+        <option name="SIM_TOC_BLANK_LINE_SPACER" value="true" />
+      </ParserOptions>
+    </ParserSettings>
+    <HtmlSettings headerTopEnabled="false" headerBottomEnabled="false" bodyTopEnabled="false" bodyBottomEnabled="false" addPageHeader="false" addAnchorLinks="false" anchorLinksWrapText="false" imageUriSerials="false" addDocTypeHtml="true" noParaTags="false" defaultUrlTitle="false" migratedPlantUml="true" migratedAnchorLinks="true" plantUmlConversion="0">
+      <GeneratorProvider>
+        <provider providerId="com.vladsch.md.nav.editor.javafx.html.generator" providerName="JavaFx/Chromium HTML Generator" />
+      </GeneratorProvider>
+      <headerTop />
+      <headerBottom />
+      <bodyTop />
+      <bodyBottom />
+      <fencedCodeConversions>
+        <option name="c4plantuml" value="NONE" />
+        <option name="ditaa" value="NONE" />
+        <option name="erd" value="NONE" />
+        <option name="graphviz" value="NONE" />
+        <option name="latex" value="KATEX" />
+        <option name="math" value="KATEX" />
+        <option name="mermaid" value="NONE" />
+        <option name="nomnoml" value="NONE" />
+        <option name="plantuml" value="NONE" />
+        <option name="puml" value="NONE" />
+        <option name="svgbob" value="NONE" />
+        <option name="umlet" value="NONE" />
+        <option name="vega" value="NONE" />
+        <option name="vegalite" value="NONE" />
+        <option name="wavedrom" value="NONE" />
+      </fencedCodeConversions>
+    </HtmlSettings>
+    <CssSettings previewScheme="UI_SCHEME" cssUri="" isCssUriEnabled="false" isCssUriSerial="true" isCssTextEnabled="false" isDynamicPageWidth="true">
+      <StylesheetProvider>
+        <provider providerId="com.vladsch.md.nav.editor.javafx.html.css" providerName="Default JavaFx/Chromium Stylesheet" />
+      </StylesheetProvider>
+      <ScriptProviders>
+        <provider providerId="com.vladsch.md.nav.editor.hljs.html.script" providerName="HighlightJS Script" />
+      </ScriptProviders>
+      <cssText />
+      <cssUriHistory />
+    </CssSettings>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Poetry (python-challenge)" project-jdk-type="Python SDK" />
+  <component name="PythonCompatibilityInspectionAdvertiser">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/python-challenge.iml" filepath="$PROJECT_DIR$/.idea/python-challenge.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/python-challenge.iml
+++ b/.idea/python-challenge.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Poetry (python-challenge)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectTasksOptions">
+    <TaskOptions isEnabled="true">
+      <option name="arguments" value="$FilePathRelativeToProjectRoot$" />
+      <option name="checkSyntaxErrors" value="true" />
+      <option name="description" />
+      <option name="exitCodeBehavior" value="ERROR" />
+      <option name="fileExtension" value="py" />
+      <option name="immediateSync" value="false" />
+      <option name="name" value="black" />
+      <option name="output" value="$FilePathRelativeToProjectRoot$" />
+      <option name="outputFilters">
+        <array />
+      </option>
+      <option name="outputFromStdout" value="false" />
+      <option name="program" value="$PROJECT_DIR$/.venv/Scripts/black.exe" />
+      <option name="runOnExternalChanges" value="false" />
+      <option name="scopeName" value="Current File" />
+      <option name="trackOnlyRoot" value="false" />
+      <option name="workingDir" value="$Projectpath$" />
+      <envs />
+    </TaskOptions>
+  </component>
+</project>

--- a/handler.py
+++ b/handler.py
@@ -12,6 +12,10 @@ logger.setLevel(logging.DEBUG)
 
 
 def addAddressRules(app_idx: int, residence_idx: int, borrower: str = "borrower"):
+    """Add a rule to the list for adding a basic address.
+
+    Helps make the code more KISS
+    """
     if borrower in {"borrower", "coborrower"}:
         return [
             {
@@ -95,10 +99,11 @@ def main(event, context=None):  # pylint: disable=unused-argument
     for loan in loans:
         # update rules based on needs of ingested data
         for app in range(len(loan["applications"])):
+            # we need to do this for each application
             borrower = loan["applications"][app]["borrower"]
             coborrower = loan["applications"][app]["coborrower"]
 
-            # always add the main borrowers address
+            # always add the main borrowers address, which is in the json already
             if borrower["mailingAddress"] != coborrower["mailingAddress"]:
                 # but only add the coborrowers address, if it is different
                 rules += addAddressRules(app, 0, "coborrower")

--- a/handler.py
+++ b/handler.py
@@ -11,10 +11,12 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-def addAddressRules(app_idx: int, residence_idx: int, borrower: str = "borrower"):
+def add_address_rules(app_idx: int, residence_idx: int, borrower: str = "borrower"):
     """Add a rule to the list for adding a basic address.
 
-    Helps make the code more KISS
+    Helps make the code more KISS. Ideally, this could all be better my making the
+    JSON path rules more like templates to apply to each application. jinja or even
+    mustache templates could work great for this.
     """
     if borrower in {"borrower", "coborrower"}:
         return [
@@ -112,10 +114,10 @@ def main(event, context=None):  # pylint: disable=unused-argument
 
 
 def process_app_rules(loan, rules):
-    """Process loan data to handle any special rules."""
+    """Process loan data to handle any special rules based on ingested data."""
 
     for app in range(len(loan["applications"])):
-        # Here we can setup a call for each check/validation we want to run
+        # Here we can setup a call for each check/validation we want to run per app
         rules = check_borrower_addresses(loan, app, rules)
 
     return rules
@@ -142,6 +144,6 @@ def check_borrower_addresses(loan, app, rules):
         # this also needs more work to properly process the extra loan data I added
         # for testing, and append all the addresses properly and not overwrite by
         # generating the correct `residence_idx`. But currently works based on ticket.
-        rules += addAddressRules(app, app, "coborrower")
+        rules += add_address_rules(app, app, "coborrower")
 
     return rules

--- a/resources/borrowers.json
+++ b/resources/borrowers.json
@@ -1,18 +1,42 @@
 [
     {
         "source": "$.applications[0].borrower.firstName",
-        "target": "$.reports[?(@.title == 'Borrowers Report')].borrowers[0].first_name"
+        "target": "$.reports[0][?(@.title == 'Borrowers Report')].borrowers[0].first_name"
     },
     {
         "source": "$.applications[0].borrower.lastName",
-        "target": "$.reports[?(@.title == 'Borrowers Report')].borrowers[0].last_name"
+        "target": "$.reports[0][?(@.title == 'Borrowers Report')].borrowers[0].last_name"
     },
     {
         "source": "$.applications[0].coborrower.firstName",
-        "target": "$.reports[?(@.title == 'Borrowers Report')].borrowers[1].first_name"
+        "target": "$.reports[0][?(@.title == 'Borrowers Report')].borrowers[1].first_name"
     },
     {
         "source": "$.applications[0].coborrower.lastName",
-        "target": "$.reports[?(@.title == 'Borrowers Report')].borrowers[1].last_name"
+        "target": "$.reports[0][?(@.title == 'Borrowers Report')].borrowers[1].last_name"
+    },
+    {
+        "source": "$.applications[0].shared_address",
+        "target": "$.reports[0][?(@.title == 'Borrowers Report')].shared_address"
+    },
+    {
+        "source": "$.applications[1].borrower.firstName",
+        "target": "$.reports[1][?(@.title == 'Borrowers Report')].borrowers[0].first_name"
+    },
+    {
+        "source": "$.applications[1].borrower.lastName",
+        "target": "$.reports[1][?(@.title == 'Borrowers Report')].borrowers[0].last_name"
+    },
+    {
+        "source": "$.applications[1].coborrower.firstName",
+        "target": "$.reports[1][?(@.title == 'Borrowers Report')].borrowers[1].first_name"
+    },
+    {
+        "source": "$.applications[1].coborrower.lastName",
+        "target": "$.reports[1][?(@.title == 'Borrowers Report')].borrowers[1].last_name"
+    },
+    {
+        "source": "$.applications[1].shared_address",
+        "target": "$.reports[1][?(@.title == 'Borrowers Report')].shared_address"
     }
 ]

--- a/resources/residences.json
+++ b/resources/residences.json
@@ -14,22 +14,5 @@
     {
         "source": "$.applications[0].borrower.mailingAddress.addressPostalCode",
         "target": "$.reports[?(@.title == 'Residences Report')].residences[0].zip"
-    },
-
-    {
-        "source": "$.applications[0].coborrower.mailingAddress.addressStreetLine1",
-        "target": "$.reports[?(@.title == 'Residences Report')].residences[1].street"
-    },
-    {
-        "source": "$.applications[0].coborrower.mailingAddress.addressCity",
-        "target": "$.reports[?(@.title == 'Residences Report')].residences[1].city"
-    },
-    {
-        "source": "$.applications[0].coborrower.mailingAddress.addressState",
-        "target": "$.reports[?(@.title == 'Residences Report')].residences[1].state"
-    },
-    {
-        "source": "$.applications[0].coborrower.mailingAddress.addressPostalCode",
-        "target": "$.reports[?(@.title == 'Residences Report')].residences[1].zip"
     }
 ]

--- a/service/dal.py
+++ b/service/dal.py
@@ -82,7 +82,7 @@ class Project:
 
     def _parse_roots_ext(self, path, file):
         """Parse given file for name and qualified extension."""
-        # paths = str(path).replace(str(self.root), '').split('/')
+        # Using Pathlib makes pathing much easier across OS's
         paths = list(Path(path).parts)
         name, *exts = file.split('.')
         ext = '.'.join(exts) or ''

--- a/service/dal.py
+++ b/service/dal.py
@@ -82,7 +82,8 @@ class Project:
 
     def _parse_roots_ext(self, path, file):
         """Parse given file for name and qualified extension."""
-        paths = str(path).replace(str(self.root), '').split('/')
+        # paths = str(path).replace(str(self.root), '').split('/')
+        paths = list(Path(path).parts)
         name, *exts = file.split('.')
         ext = '.'.join(exts) or ''
 

--- a/tests/loandata.json
+++ b/tests/loandata.json
@@ -20,7 +20,30 @@
                     "addressState": "TX",
                     "addressPostalCode": "75028"
                 }
-            }
+            },
+            "shared_address": false
+        },{
+            "borrower": {
+                "firstName": "Jimbob",
+                "lastName": "Smith",
+                "mailingAddress": {
+                    "addressStreetLine1": "1235 FAKE DR",
+                    "addressCity": "FLOWER MOUND",
+                    "addressState": "TX",
+                    "addressPostalCode": "75028"
+                }
+            },
+            "coborrower": {
+                "firstName": "Jolena",
+                "lastName": "Smith",
+                "mailingAddress": {
+                    "addressStreetLine1": "1234 FAKE DR",
+                    "addressCity": "FLOWER MOUND",
+                    "addressState": "TX",
+                    "addressPostalCode": "75028"
+                }
+            },
+            "shared_address": false
         }
     ],
     "property": {

--- a/tests/reports.json
+++ b/tests/reports.json
@@ -1,23 +1,6 @@
 {
   "reports": [
     {
-      "title": "Residences Report",
-      "residences": [
-        {
-          "street": "123 EXAMPLE PKWY.",
-          "city": "FLOWER MOUND",
-          "state": "TX",
-          "zip": "75028"
-        },
-        {
-          "street": "123 EXAMPLE PKWY.",
-          "city": "FLOWER MOUND",
-          "state": "TX",
-          "zip": "75028"
-        }
-      ]
-    },
-    {
       "title": "Borrowers Report",
       "borrowers": [
         {
@@ -27,6 +10,17 @@
         {
           "first_name": "JOHN",
           "last_name": "DOE"
+        }
+      ]
+    },
+    {
+      "title": "Residences Report",
+      "residences": [
+        {
+          "street": "123 EXAMPLE PKWY.",
+          "city": "FLOWER MOUND",
+          "state": "TX",
+          "zip": "75028"
         }
       ]
     }

--- a/tests/reports.json
+++ b/tests/reports.json
@@ -11,13 +11,34 @@
           "first_name": "JOHN",
           "last_name": "DOE"
         }
-      ]
+      ],
+      "shared_address": true
+    },
+    {
+      "title": "Borrowers Report",
+      "borrowers": [
+        {
+          "first_name": "Jimbob",
+          "last_name": "Smith"
+        },
+        {
+          "first_name": "Jolena",
+          "last_name": "Smith"
+        }
+      ],
+      "shared_address": false
     },
     {
       "title": "Residences Report",
       "residences": [
         {
           "street": "123 EXAMPLE PKWY.",
+          "city": "FLOWER MOUND",
+          "state": "TX",
+          "zip": "75028"
+        },
+        {
+          "street": "1234 FAKE DR",
           "city": "FLOWER MOUND",
           "state": "TX",
           "zip": "75028"

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -2,6 +2,7 @@ import os
 import sys
 import json
 import logging
+from pprint import pprint as print
 
 # Initialize Logging
 for handler in logging.root.handlers[:]:

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -2,7 +2,6 @@ import os
 import sys
 import json
 import logging
-from pprint import pprint as print
 
 # Initialize Logging
 for handler in logging.root.handlers[:]:


### PR DESCRIPTION
In order to test this properly, I added another application that has a different address between borrower, and coborrower. According to the tickets CC-01/CC-02/CC-03 this works.

But there is still one issue. On subsequent applications, it only adds the coborrowers address to the Residences Report. This is because we need to dynamically generate the indexes in the rules. Currently they are something like
```json
{
        "source": "$.applications[0].borrower.mailingAddress.addressPostalCode",
        "target": "$.reports[?(@.title == 'Residences Report')].residences[0].zip"
    }
```
but they need to be processed like a template possibly. so maybe the initial rules look like:
```json
{
        "source": "$.applications[{{app_id}}].borrower.mailingAddress.addressPostalCode",
        "target": "$.reports[?(@.title == 'Residences Report')].residences[{{residence_id}}].zip"
    }
```
and so on for the other rules for residences/borrowers. then we can grab those in python, and while iterating over the applications, we can replace those with fully generated rules by replacing `{{app_id}}` with the actual desired output. or in cases of the residence report, just create a json object of the address and just append it to the list.

Other things I would like to do when knowing more of the application, is as noted in the `check_borrower_addresses(...)` method, is to not magically update the `loan` object like I am doing as it is implicit and could cause confusion. Usually if code like this is running async we might want to send copies of these objects to process and simply append the new data, or replace them. Making it more implicit and obvious where data is being manipulated.